### PR TITLE
feat(command list): scrolling to the item when navigating with keyboard

### DIFF
--- a/ui/editor/extensions/slash-command.tsx
+++ b/ui/editor/extensions/slash-command.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactNode } from "react";
+import React, { useState, useEffect, useCallback, ReactNode, useRef, useLayoutEffect } from "react";
 import { Editor, Range, Extension } from "@tiptap/core";
 import Suggestion from "@tiptap/suggestion";
 import { ReactRenderer } from "@tiptap/react";
@@ -63,7 +63,7 @@ const getSuggestionItems = ({ query }: { query: string }) => {
     {
       title: "Continue writing",
       description: "Use AI to expand your thoughts.",
-      icon: <Magic className="w-7 text-black" />,
+      icon: <Magic className="text-black w-7" />,
     },
     {
       title: "Heading 1",
@@ -130,6 +130,20 @@ const getSuggestionItems = ({ query }: { query: string }) => {
     return true;
   });
   // .slice(0, 10);
+};
+
+export const updateScrollView = (container: HTMLElement, item: HTMLElement) => {
+  const containerHeight = container.offsetHeight;
+  const itemHeight = item ? item.offsetHeight : 0;
+
+  const top = item.offsetTop;
+  const bottom = top + itemHeight;
+
+  if (top < container.scrollTop) {
+    container.scrollTop -= container.scrollTop - top + 5;
+  } else if (bottom > containerHeight + container.scrollTop) {
+    container.scrollTop += bottom - containerHeight - container.scrollTop + 5;
+  }
 };
 
 const CommandList = ({
@@ -216,8 +230,21 @@ const CommandList = ({
     setSelectedIndex(0);
   }, [items]);
 
+  const commandListContainer = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const container = commandListContainer?.current
+
+    const item = (container?.children[selectedIndex] as HTMLElement)
+
+    if (item && container) updateScrollView(container, item)
+  }, [selectedIndex])
+
   return items.length > 0 ? (
-    <div className="z-50 h-auto max-h-[350px] w-72 overflow-y-auto rounded-md border border-gray-200 bg-white px-1 py-2 shadow-md transition-all">
+    <div 
+      ref={commandListContainer}
+      className="z-50 h-auto max-h-[350px] w-72 overflow-y-auto rounded-md border border-gray-200 bg-white px-1 py-2 shadow-md transition-all scroll-smooth"
+    >
       {items.map((item: CommandItemProps, index: number) => {
         return (
           <button
@@ -227,7 +254,7 @@ const CommandList = ({
             key={index}
             onClick={() => selectItem(index)}
           >
-            <div className="flex h-10 w-10 items-center justify-center rounded-md border border-stone-200 bg-white">
+            <div className="flex items-center justify-center w-10 h-10 bg-white border rounded-md border-stone-200">
               {item.title === "Continue writing" && isLoading ? (
                 <LoadingCircle />
               ) : (

--- a/ui/editor/extensions/slash-command.tsx
+++ b/ui/editor/extensions/slash-command.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useEffect, useCallback, ReactNode, useRef, useLayoutEffect } from "react";
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  ReactNode,
+  useRef,
+  useLayoutEffect,
+} from "react";
 import { Editor, Range, Extension } from "@tiptap/core";
 import Suggestion from "@tiptap/suggestion";
 import { ReactRenderer } from "@tiptap/react";
@@ -63,7 +70,7 @@ const getSuggestionItems = ({ query }: { query: string }) => {
     {
       title: "Continue writing",
       description: "Use AI to expand your thoughts.",
-      icon: <Magic className="text-black w-7" />,
+      icon: <Magic className="w-7 text-black" />,
     },
     {
       title: "Heading 1",
@@ -230,20 +237,20 @@ const CommandList = ({
     setSelectedIndex(0);
   }, [items]);
 
-  const commandListContainer = useRef<HTMLDivElement>(null)
+  const commandListContainer = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
-    const container = commandListContainer?.current
+    const container = commandListContainer?.current;
 
-    const item = (container?.children[selectedIndex] as HTMLElement)
+    const item = container?.children[selectedIndex] as HTMLElement;
 
-    if (item && container) updateScrollView(container, item)
-  }, [selectedIndex])
+    if (item && container) updateScrollView(container, item);
+  }, [selectedIndex]);
 
   return items.length > 0 ? (
-    <div 
+    <div
       ref={commandListContainer}
-      className="z-50 h-auto max-h-[350px] w-72 overflow-y-auto rounded-md border border-gray-200 bg-white px-1 py-2 shadow-md transition-all scroll-smooth"
+      className="z-50 h-auto max-h-[330px] w-72 overflow-y-auto scroll-smooth rounded-md border border-gray-200 bg-white px-1 py-2 shadow-md transition-all"
     >
       {items.map((item: CommandItemProps, index: number) => {
         return (
@@ -254,7 +261,7 @@ const CommandList = ({
             key={index}
             onClick={() => selectItem(index)}
           >
-            <div className="flex items-center justify-center w-10 h-10 bg-white border rounded-md border-stone-200">
+            <div className="flex h-10 w-10 items-center justify-center rounded-md border border-stone-200 bg-white">
               {item.title === "Continue writing" && isLoading ? (
                 <LoadingCircle />
               ) : (


### PR DESCRIPTION
<details open>
<summary> Demo </summary>

https://github.com/steven-tey/novel/assets/45892659/cd053971-0ace-4d12-8e5e-64fa1bfe13ea

</details>

In demo, I reduced the height of the `commandListContainer` to `h-56`, but reverted it to `h-auto` after I tested it. 

---

closes #6 