### PR TITLE
fix: full width ai bubble menu

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,3 +16,7 @@
   pointer-events: none;
   height: 0;
 }
+
+#tippy-2 {
+    @apply w-full max-w-screen-lg;
+  }

--- a/ui/editor/components/bubble-menu/ai.tsx
+++ b/ui/editor/components/bubble-menu/ai.tsx
@@ -19,6 +19,7 @@ const AIBubbleMenu: React.FC<Props> = ({ editor }: Props) => {
     <BubbleMenu
       editor={editor}
       tippyOptions={{
+        maxWidth: "100%",
         placement: "bottom",
         popperOptions: {
           strategy: "fixed",


### PR DESCRIPTION
Apparently, Tippy's [maxWidth is set to 350px](https://atomiks.github.io/tippyjs/v6/all-props/#maxwidth) by default...

However, changing that option alone doesn't give it full width. I had to directly target the `tippy-2` element to get this to work. (see #30)

<img width="1239" alt="image" src="https://github.com/steven-tey/novel/assets/20306749/76d0ae5f-246b-4f6f-ad36-8f7e125b78ac">


Note: was looking at Notion's menu and i think that constraining the menu to be inside the text editor would be better. For reference: 

<img width="855" alt="image" src="https://github.com/steven-tey/novel/assets/20306749/d808e815-808a-4dfd-a14a-9414c109eddf">
 