### PR TITLE
fix: prevent browser spellcheck in inline-code/code blocks

### DIFF
--- a/ui/editor/extensions/index.tsx
+++ b/ui/editor/extensions/index.tsx
@@ -84,7 +84,6 @@ export const TiptapExtensions = [
     HTMLAttributes: {
       class:
         "text-stone-400 underline underline-offset-[3px] hover:text-stone-600 transition-colors cursor-pointer",
-      spellcheck: "false",
     },
   }),
   TiptapImage.configure({

--- a/ui/editor/extensions/index.tsx
+++ b/ui/editor/extensions/index.tsx
@@ -44,6 +44,7 @@ export const TiptapExtensions = [
       HTMLAttributes: {
         class:
           "rounded-md bg-stone-200 px-1.5 py-1 font-mono font-medium text-black",
+        spellcheck: "false",
       },
     },
     horizontalRule: false,
@@ -83,6 +84,7 @@ export const TiptapExtensions = [
     HTMLAttributes: {
       class:
         "text-stone-400 underline underline-offset-[3px] hover:text-stone-600 transition-colors cursor-pointer",
+      spellcheck: "false",
     },
   }),
   TiptapImage.configure({


### PR DESCRIPTION
Prevent spellcheck from leaving red underlines in code.

*Turning this...*
![Screenshot of the novel.sh editor with many red squiggly lines for spellcheck under words in links and code](https://github.com/steven-tey/novel/assets/47499684/48b7a9e7-3912-41b2-bfba-5d62838b03de)

*Into this!*
![lScreenshot of the novel.sh editor with no red squiggly lines](https://github.com/steven-tey/novel/assets/47499684/5f30b475-703a-49d3-8ead-0f987d28e32b)

Spellcheck still works as expected in normal text blocks:
<img width="124" alt="Spellcheck red squiggly lines under the word 'mispelled'" src="https://github.com/steven-tey/novel/assets/47499684/a9f8a420-df88-4e93-af0d-e38d82bf0075">
