### PR TITLE
fix(api): Slice content from the end to prioritize later characters

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -43,7 +43,8 @@ export async function POST(req: Request): Promise<Response> {
   // remove line breaks,
   // remove trailing slash,
   // limit to 5000 characters
-  content = content.replace(/\n/g, " ").replace(/\/$/, "").slice(0, 5000);
+  // slice the content from the end to prioritize later characters
+  content = content.replace(/\n/g, " ").replace(/\/$/, "").slice(-5000);
 
   const response = await openai.createChatCompletion({
     model: "gpt-3.5-turbo",


### PR DESCRIPTION
The current implementation is to cut the content from the top and stop after 5000 characters.
If the article/document is longer than 5000 characters, the content will always be the same, and the Chat completion function will be stuck repeating the same answers (wrong answers in this case)

**Fix:** 
- To cut the content from the bottom to make sure we feed the Chat completion function the latest text.