### PR TITLE
Prioritize file over HTML in DnD/paste

### DIFF
--- a/ui/editor/props.ts
+++ b/ui/editor/props.ts
@@ -24,7 +24,8 @@ export const TiptapEditorProps: EditorProps = {
     ) {
       event.preventDefault();
       const file = event.clipboardData.files[0];
-      return handleImageUpload(file, view, event);
+      handleImageUpload(file, view, event);
+      return true;
     }
     return false;
   },
@@ -37,7 +38,8 @@ export const TiptapEditorProps: EditorProps = {
     ) {
       event.preventDefault();
       const file = event.dataTransfer.files[0];
-      return handleImageUpload(file, view, event);
+      handleImageUpload(file, view, event);
+      return true;
     }
     return false;
   },


### PR DESCRIPTION
This pull request improves the handling of drag and drop and paste events in the editor to prioritize file uploads when both HTML and file content are present. Previously, the editor was inserting an HTML image node alongside the uploaded file, causing duplication.

To reproduce the issue:

- Drag and drop an image from an external source or paste an image from the clipboard into the editor.
- Notice that both the HTML image node and the uploaded file are inserted, resulting in duplication.

To address this issue, the handleDrop and handlePaste functions in the editor component were updated to properly handle cases where both HTML and file content are present. Now, when both are detected, only the file is uploaded, and the HTML image node is not inserted.