### PR TITLE
added no OPENAI key set support

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -11,11 +11,14 @@ const openai = new OpenAIApi(config);
 export const runtime = "edge";
 
 export async function POST(req: Request): Promise<Response> {
-  // Check if the OPENAI_API_KEY is set
+  // Check if the OPENAI_API_KEY is set, if not return 400
   if (!process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY === "") {
-    return new Response("OPENAI_API_KEY is not set", {
-      status: 500,
-    });
+    return new Response(
+      "Missing OPENAI_API_KEY – make sure to add it to your .env file.",
+      {
+        status: 400,
+      },
+    );
   }
   if (
     process.env.NODE_ENV != "development" &&
@@ -71,10 +74,10 @@ export async function POST(req: Request): Promise<Response> {
     n: 1,
   });
 
-  // If the response is unauthorized, return a 500 error
+  // If the response is unauthorized, return a 401 error
   if (response.status === 401) {
     return new Response("Error: You are unauthorized to perform this action", {
-      status: 500,
+      status: 401,
     });
   }
   // Convert the response into a friendly text-stream

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -11,6 +11,12 @@ const openai = new OpenAIApi(config);
 export const runtime = "edge";
 
 export async function POST(req: Request): Promise<Response> {
+  // Check if the OPENAI_API_KEY is set
+  if (!process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY === "") {
+    return new Response("OPENAI_API_KEY is not set", {
+      status: 500,
+    });
+  }
   if (
     process.env.NODE_ENV != "development" &&
     process.env.KV_REST_API_URL &&
@@ -65,6 +71,12 @@ export async function POST(req: Request): Promise<Response> {
     n: 1,
   });
 
+  // If the response is unauthorized, return a 500 error
+  if (response.status === 401) {
+    return new Response("Error: You are unauthorized to perform this action", {
+      status: 500,
+    });
+  }
   // Convert the response into a friendly text-stream
   const stream = OpenAIStream(response);
 


### PR DESCRIPTION
PR Description: Resolve issue #86 by enhancing error handling for the OpenAI API key. 
When the API key is not set, it now displays a clear message in the toast box indicating that no API key is set. 
Additionally, if an invalid API key is provided, it shows an "Unauthorized" error message in the toast box, improving user feedback and error resolution.




