### PR TITLE
Fixed empty "link" input string

### DIFF
--- a/ui/editor/components/link-selector.tsx
+++ b/ui/editor/components/link-selector.tsx
@@ -43,7 +43,8 @@ export const LinkSelector: FC<LinkSelectorProps> = ({
           onSubmit={(e) => {
             e.preventDefault();
             const input = e.target[0] as HTMLInputElement;
-            input.value ? editor.chain().focus().setLink({ href: input.value }).run() : "";
+            input.value &&
+              editor.chain().focus().setLink({ href: input.value }).run();
             setIsOpen(false);
           }}
           className="fixed top-full z-[99999] mt-1 flex w-60 overflow-hidden rounded border border-stone-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-top-1"

--- a/ui/editor/components/link-selector.tsx
+++ b/ui/editor/components/link-selector.tsx
@@ -43,7 +43,7 @@ export const LinkSelector: FC<LinkSelectorProps> = ({
           onSubmit={(e) => {
             e.preventDefault();
             const input = e.target[0] as HTMLInputElement;
-            editor.chain().focus().setLink({ href: input.value }).run();
+            input.value ? editor.chain().focus().setLink({ href: input.value }).run() : "";
             setIsOpen(false);
           }}
           className="fixed top-full z-[99999] mt-1 flex w-60 overflow-hidden rounded border border-stone-200 bg-white p-1 shadow-xl animate-in fade-in slide-in-from-top-1"


### PR DESCRIPTION
If you select text and click the checkmark icon to add a link to a document without actually inserting a link, an empty link is created. I have resolved this issue.

Bug:
![Bug](https://github.com/steven-tey/novel/assets/65452005/b84cdfc1-a233-4b36-ae49-8e6fd8a617c1)


Here's what has been fixed:
![Changes fixed](https://github.com/steven-tey/novel/assets/65452005/8cff0572-12a8-4555-a675-ee4849ed4c87)

Thank you!
