### PR TITLE
Hide inapplicable plugins from bubble-menu

### DIFF
--- a/ui/editor/components/bubble-menu.tsx
+++ b/ui/editor/components/bubble-menu.tsx
@@ -78,6 +78,8 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
   const [isNodeSelectorOpen, setIsNodeSelectorOpen] = useState(false);
   const [isColorSelectorOpen, setIsColorSelectorOpen] = useState(false);
   const [isLinkSelectorOpen, setIsLinkSelectorOpen] = useState(false);
+  const isCodeActive = props.editor.isActive("code");
+  const isCodeBlockActive = props.editor.isActive("codeBlock");
 
   return (
     <BubbleMenu
@@ -93,39 +95,43 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
           setIsLinkSelectorOpen(false);
         }}
       />
-      <LinkSelector
-        editor={props.editor}
-        isOpen={isLinkSelectorOpen}
-        setIsOpen={() => {
-          setIsLinkSelectorOpen(!isLinkSelectorOpen);
-          setIsColorSelectorOpen(false);
-          setIsNodeSelectorOpen(false);
-        }}
-      />
-      <div className="flex">
-        {items.map((item, index) => (
-          <button
-            key={index}
-            onClick={item.command}
-            className="p-2 text-stone-600 hover:bg-stone-100 active:bg-stone-200"
-          >
-            <item.icon
-              className={cn("h-4 w-4", {
-                "text-blue-500": item.isActive(),
-              })}
-            />
-          </button>
-        ))}
-      </div>
-      <ColorSelector
-        editor={props.editor}
-        isOpen={isColorSelectorOpen}
-        setIsOpen={() => {
-          setIsColorSelectorOpen(!isColorSelectorOpen);
-          setIsNodeSelectorOpen(false);
-          setIsLinkSelectorOpen(false);
-        }}
-      />
+      {!(isCodeActive || isCodeBlockActive) && (
+        <>
+          <LinkSelector
+            editor={props.editor}
+            isOpen={isLinkSelectorOpen}
+            setIsOpen={() => {
+              setIsLinkSelectorOpen(!isLinkSelectorOpen);
+              setIsColorSelectorOpen(false);
+              setIsNodeSelectorOpen(false);
+            }}
+          />
+          <div className="flex">
+            {items.map((item, index) => (
+              <button
+                key={index}
+                onClick={item.command}
+                className="p-2 text-stone-600 hover:bg-stone-100 active:bg-stone-200"
+              >
+                <item.icon
+                  className={cn("h-4 w-4", {
+                    "text-blue-500": item.isActive(),
+                  })}
+                />
+              </button>
+            ))}
+          </div>
+          <ColorSelector
+            editor={props.editor}
+            isOpen={isColorSelectorOpen}
+            setIsOpen={() => {
+              setIsColorSelectorOpen(!isColorSelectorOpen);
+              setIsNodeSelectorOpen(false);
+              setIsLinkSelectorOpen(false);
+            }}
+          />
+        </>
+      )}
     </BubbleMenu>
   );
 };


### PR DESCRIPTION
## Summary
Hide all inapplicable plugins from the bubble menu for `CodeBlock` and `Code`.

> This PR is dependent on #117 and will have to be updated once #117 is merged.

### Existing Scenario
When `CodeBlock `is active, other inapplicable plugins (link-selector, bold, italic, other text-decoration plugins...) are visible (and ineffective).

![image](https://github.com/steven-tey/novel/assets/18103669/d5132ba5-ed35-4550-be6f-33cbb74c12e0)

### Updated Scenario
Only `Node Selector` is visible, and changing node activates other plugins in the bubble menu.

![image](https://github.com/steven-tey/novel/assets/18103669/8c2b43cf-dcb7-47a2-aa7b-a78a799e435d)

