### PR TITLE
fix: image placeholder implementation breaking (#145)

### DIFF
--- a/packages/core/src/ui/editor/plugins/upload-images.tsx
+++ b/packages/core/src/ui/editor/plugins/upload-images.tsx
@@ -104,7 +104,7 @@ export function startImageUpload(file: File, view: EditorView, pos: number) {
 
     const node = schema.nodes.image.create({ src: imageSrc });
     const transaction = view.state.tr
-      .replaceWith(pos, pos, node)
+      .replaceSelectionWith(node)
       .setMeta(uploadKey, { remove: { id } });
     view.dispatch(transaction);
   });


### PR DESCRIPTION
Position being set was out of range.

Found a solution from Prosemirror [forum](https://discuss.prosemirror.net/t/rangeerror-position-x-out-of-range/876)

After the change placeholder image is rendered correctly:

https://github.com/steven-tey/novel/assets/41156157/16aacad5-3d62-4cc4-a460-d1d7a0c44260





