### PR TITLE
fix: draggable icon is misplaced in ordered and unordered lists (#146)

### DIFF
--- a/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
+++ b/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
@@ -150,7 +150,7 @@ function DragHandle(options: DragHandleOptions) {
             y: event.clientY,
           });
 
-          if (!(node instanceof Element)) {
+          if (!(node instanceof Element) || node.matches("ul, ol")) {
             hideDragHandle();
             return;
           }


### PR DESCRIPTION
Fix for issue #146 

Have disabled `drag-handle` element for `ul` and `ol`.

The `drag-handle` for list items should now display properly: 

https://github.com/steven-tey/novel/assets/28751435/23401728-a441-47f6-a864-d9a83a792adb

