### PR TITLE
Pass in `completionApi` prop to suggested commands

### DIFF
--- a/packages/core/src/ui/editor/extensions/index.tsx
+++ b/packages/core/src/ui/editor/extensions/index.tsx
@@ -10,14 +10,14 @@ import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import { Markdown } from "tiptap-markdown";
 import Highlight from "@tiptap/extension-highlight";
-import SlashCommand from "./slash-command";
+import { CreateSlashCommand } from "./slash-command";
 import { InputRule } from "@tiptap/core";
 import UploadImagesPlugin from "@/ui/editor/plugins/upload-images";
 import UpdatedImage from "./updated-image";
 import CustomKeymap from "./custom-keymap";
 import DragAndDrop from "./drag-and-drop";
 
-export const defaultExtensions = [
+export const defaultExtensions = (completionApi: string) => [
   StarterKit.configure({
     bulletList: {
       HTMLAttributes: {
@@ -115,7 +115,7 @@ export const defaultExtensions = [
     },
     includeChildren: true,
   }),
-  SlashCommand,
+  CreateSlashCommand(completionApi),
   TiptapUnderline,
   TextStyle,
   Color,

--- a/packages/core/src/ui/editor/extensions/slash-command.tsx
+++ b/packages/core/src/ui/editor/extensions/slash-command.tsx
@@ -248,17 +248,19 @@ const CommandList = ({
   command,
   editor,
   range,
+  completionApi,
 }: {
   items: CommandItemProps[];
   command: any;
   editor: any;
   range: any;
+  completionApi: string;
 }) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const { complete, isLoading } = useCompletion({
     id: "novel",
-    api: "/api/generate",
+    api: completionApi,
     onResponse: (response) => {
       if (response.status === 429) {
         toast.error("You have reached your request limit for the day.");
@@ -375,14 +377,17 @@ const CommandList = ({
   ) : null;
 };
 
-const renderItems = () => {
+const renderItems = (completionApi: string) => {
   let component: ReactRenderer | null = null;
   let popup: any | null = null;
 
   return {
     onStart: (props: { editor: Editor; clientRect: DOMRect }) => {
       component = new ReactRenderer(CommandList, {
-        props,
+        props: {
+          completionApi,
+          ...props,
+        },
         editor: props.editor,
       });
 
@@ -422,11 +427,9 @@ const renderItems = () => {
   };
 };
 
-const SlashCommand = Command.configure({
+export const CreateSlashCommand = (completionApi: string) => Command.configure({
   suggestion: {
     items: getSuggestionItems,
-    render: renderItems,
+    render: () => renderItems(completionApi),
   },
 });
-
-export default SlashCommand;

--- a/packages/core/src/ui/editor/index.tsx
+++ b/packages/core/src/ui/editor/index.tsx
@@ -100,7 +100,7 @@ export default function Editor({
   }, debounceDuration);
 
   const editor = useEditor({
-    extensions: [...defaultExtensions, ...extensions],
+    extensions: [...defaultExtensions(completionApi), ...extensions],
     editorProps: {
       ...defaultEditorProps,
       ...editorProps,


### PR DESCRIPTION
Closes #133 

Passing in `completionApi` through to `slash-commands.tsx` so that the same route can be used for when using the `Continue writing` command as the `++` quick command. 