### PR TITLE
feat: add onInit prop with editor instance

### DIFF
--- a/packages/core/src/ui/editor/index.tsx
+++ b/packages/core/src/ui/editor/index.tsx
@@ -23,6 +23,7 @@ export default function Editor({
   defaultValue = defaultEditorContent,
   extensions = [],
   editorProps = {},
+  onInit = () => {},
   onUpdate = () => {},
   onDebouncedUpdate = () => {},
   debounceDuration = 750,
@@ -55,6 +56,12 @@ export default function Editor({
    */
   editorProps?: EditorProps;
   /**
+   * A callback function that is called whenever the editor is initialized.
+   * Defaults to () => {}.
+   */
+  // eslint-disable-next-line no-unused-vars
+  onInit?: (editor?: EditorClass) => void | Promise<void>;
+  /**
    * A callback function that is called whenever the editor is updated.
    * Defaults to () => {}.
    */
@@ -85,6 +92,7 @@ export default function Editor({
   const [content, setContent] = useLocalStorage(storageKey, defaultValue);
 
   const [hydrated, setHydrated] = useState(false);
+  const [initialized, setInitialized] = useState(false);
 
   const debouncedUpdates = useDebouncedCallback(async ({ editor }) => {
     const json = editor.getJSON();
@@ -125,6 +133,13 @@ export default function Editor({
     },
     autofocus: "end",
   });
+
+  useEffect(() => {
+    if (!editor || initialized) return;
+
+    onInit(editor);
+    setInitialized(true);
+  }, [editor, initialized, onInit]);
 
   const { complete, completion, isLoading, stop } = useCompletion({
     id: "novel",


### PR DESCRIPTION
fixes https://github.com/steven-tey/novel/issues/163
fixes https://github.com/steven-tey/novel/issues/144

This PR adds an onInit hook, which exposes the underlying tiptap editor instance to the parent component, needed for customizations.

As alternative I was thinking, that it would be nice to expose a `useEditor` hook, similar to how tiptap does it, just with the novel enhancements already included. This could be added additionally to the onInit hook in this PR (so no matter the decision, we could just merge this.)
https://github.com/steven-tey/novel/pull/136 seems to go into a similar direction, but does much more. If you are interested in a lean hook alternative, I could make a PR for that, too.
