### PR TITLE
Add disable note in README.md about AI Completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ To set up Novel locally, you'll need to clone the repository and set up the foll
 - `OPENAI_API_KEY` – your OpenAI API key (you can get one [here](https://platform.openai.com/account/api-keys))
 - `BLOB_READ_WRITE_TOKEN` – your Vercel Blob read/write token (currently [still in beta](https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart), but feel free to [sign up on this form](https://vercel.fyi/blob-beta) for access)
 
+> **Note**: If you want to 'disable' AI completions, enter 'disable' as the `OPENAI_API_KEY`, so AI features will not be accessible.
+
 If you've deployed this to Vercel, you can also use [`vc env pull`](https://vercel.com/docs/cli/env#exporting-development-environment-variables) to pull the environment variables from your Vercel project.
 
 To run the app locally, you can run the following commands:


### PR DESCRIPTION
Added a note under the `OPENAI_API_KEY` specifying that to disable AI features (as this came up a lot in issues) just enter some random string (in this case `disable`) so the ++ hotcut and the AI button doesn't work.

Was just asked by some users in issues. Simple readme fix.