### PR TITLE
Fix novel styling affecting other TipTap instances

### DIFF
--- a/packages/core/src/styles/prosemirror.css
+++ b/packages/core/src/styles/prosemirror.css
@@ -1,15 +1,11 @@
-.ProseMirror {
-  @apply novel-p-12 novel-px-8 sm:novel-px-12;
-}
-
-.ProseMirror .is-editor-empty:first-child::before {
+.novel-tiptap .is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;
   color: var(--novel-stone-400);
   pointer-events: none;
   height: 0;
 }
-.ProseMirror .is-empty::before {
+.novel-tiptap .is-empty::before {
   content: attr(data-placeholder);
   float: left;
   color: var(--novel-stone-400);
@@ -19,7 +15,7 @@
 
 /* Custom image styles */
 
-.ProseMirror img {
+.novel-tiptap img {
   transition: filter 0.1s ease-in-out;
 
   &:hover {

--- a/packages/core/src/ui/editor/props.ts
+++ b/packages/core/src/ui/editor/props.ts
@@ -3,7 +3,7 @@ import { startImageUpload } from "@/ui/editor/plugins/upload-images";
 
 export const defaultEditorProps: EditorProps = {
   attributes: {
-    class: `novel-prose-lg novel-prose-stone dark:novel-prose-invert prose-headings:novel-font-title novel-font-default focus:novel-outline-none novel-max-w-full`,
+    class: `novel-tiptap novel-p-12 novel-px-8 sm:novel-px-12 novel-prose-lg novel-prose-stone dark:novel-prose-invert prose-headings:novel-font-title novel-font-default focus:novel-outline-none novel-max-w-full`,
   },
   handleDOMEvents: {
     keydown: (_view, event) => {


### PR DESCRIPTION
With the current implementation, every single instance of TipTap inside an application is affected by the styling of this library.

This is due the global `.Prosemirror` styling in the `prosemirror.css` file, e.g.

```
.ProseMirror {
  @apply novel-p-12 novel-px-8 sm:novel-px-12;
}
.ProseMirror .is-editor-empty:first-child::before {
  content: attr(data-placeholder);
  float: left;
  color: var(--novel-stone-400);
  pointer-events: none;
  height: 0;
}
.ProseMirror .is-empty::before {
  content: attr(data-placeholder);
  float: left;
  color: var(--novel-stone-400);
  height: 0;
}
```

As an easy fix, I've introduced a custom `.novel-tiptap` css class and included it inside the `defaultEditorProps` object and replaced the `.ProseMirror` classes (where applicable without side effects):

```
.novel-tiptap .is-editor-empty:first-child::before {
  content: attr(data-placeholder);
  float: left;
  color: var(--novel-stone-400);
  pointer-events: none;
  height: 0;
}
.novel-tiptap .is-empty::before {
  content: attr(data-placeholder);
  float: left;
  color: var(--novel-stone-400);
  pointer-events: none;
  height: 0;
}
```

I've also moved the `novel-p-12 novel-px-8 sm:novel-px-12` part to the `defaultEditorProps` object, since I've found it odd, that there were 2 places where the editor was styled with tailwindcss. This also allows to override the padding, which was not possible before.
