### PR TITLE
fix: drag handle hide class

### DIFF
--- a/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
+++ b/packages/core/src/ui/editor/extensions/drag-and-drop.tsx
@@ -104,13 +104,13 @@ function DragHandle(options: DragHandleOptions) {
 
   function hideDragHandle() {
     if (dragHandleElement) {
-      dragHandleElement.classList.add("hidden");
+      dragHandleElement.classList.add("hide");
     }
   }
 
   function showDragHandle() {
     if (dragHandleElement) {
-      dragHandleElement.classList.remove("hidden");
+      dragHandleElement.classList.remove("hide");
     }
   }
 


### PR DESCRIPTION
I noticed a mismatch in the [hide and show drag handle functions](https://github.com/steven-tey/novel/blob/main/packages/core/src/ui/editor/extensions/drag-and-drop.tsx#L107) and the [prose mirror css](https://github.com/steven-tey/novel/blob/main/packages/core/src/styles/prosemirror.css#L157), which meant the drag handle wasn't hiding properly and stayed in position on screen when scrolling, given the element is `position:fixed`. 