### PR TITLE
Export defaultExtensions

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,4 +2,5 @@ import "./styles/index.css";
 import "./styles/tailwind.css";
 import "./styles/prosemirror.css";
 
+export { defaultExtensions } from "./ui/editor/extensions";
 export { default as Editor } from "./ui/editor";


### PR DESCRIPTION
I need access to the defaultExtensions for collab reasons. Can we export it? Others might find it useful as well