### PR TITLE
[Fix] - Correct License Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ Here's how you can contribute:
 
 ## License
 
-Licensed under the [Apache-2.0 license](https://github.com/steven-tey/novel/blob/main/LICENSE.md).
+Licensed under the [Apache-2.0 license](https://github.com/steven-tey/novel/blob/main/LICENSE).


### PR DESCRIPTION
### Context:

Existing license link in the `README.md` file is incorrect and includes the `.md` extension. This is not needed and results in a broken link. To resolve, I've opened this PR and have [updated the link](https://github.com/steven-tey/novel/commit/62b70c189b74f4e2c4a6c9245c71d81334f7893a) so that it routes to the proper location. 

**Reference:**
- Existing Link: [here](https://github.com/steven-tey/novel/blob/main/LICENSE.md)
- Updated Link: [here](https://github.com/steven-tey/novel/blob/main/LICENSE)