### PR TITLE
fix: image move when dragged

### DIFF
--- a/apps/web/styles/prosemirror.css
+++ b/apps/web/styles/prosemirror.css
@@ -123,7 +123,6 @@ ul[data-type="taskList"] li[data-checked="true"] > div > p {
 
 .ProseMirror:not(.dragging) .ProseMirror-selectednode {
   outline: none !important;
-  border-radius: 0.2rem;
   background-color: var(--novel-highlight-blue);
   transition: background-color 0.2s;
   box-shadow: none;

--- a/packages/headless/src/extensions/drag-and-drop.tsx
+++ b/packages/headless/src/extensions/drag-and-drop.tsx
@@ -27,16 +27,26 @@ function nodeDOMAtCoords(coords: { x: number; y: number }) {
       (elem: Element) =>
         elem.parentElement?.matches?.(".ProseMirror") ||
         elem.matches(
-          ["li", "p:not(:first-child)", "pre", "blockquote", "h1, h2, h3, h4, h5, h6"].join(", ")
+          [
+            "li",
+            "p:not(:first-child)",
+            "pre",
+            "blockquote",
+            "h1, h2, h3, h4, h5, h6",
+          ].join(", ")
         )
     );
 }
 
-function nodePosAtDOM(node: Element, view: EditorView) {
+function nodePosAtDOM(
+  node: Element,
+  view: EditorView,
+  options: DragHandleOptions
+) {
   const boundingRect = node.getBoundingClientRect();
 
   return view.posAtCoords({
-    left: boundingRect.left + 1,
+    left: boundingRect.left + 50 + options.dragHandleWidth,
     top: boundingRect.top + 1,
   })?.inside;
 }
@@ -54,10 +64,12 @@ function DragHandle(options: DragHandleOptions) {
 
     if (!(node instanceof Element)) return;
 
-    const nodePos = nodePosAtDOM(node, view);
+    const nodePos = nodePosAtDOM(node, view, options);
     if (nodePos == null || nodePos < 0) return;
 
-    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, nodePos)));
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, nodePos))
+    );
 
     const slice = view.state.selection.content();
     const { dom, text } = __serializeForClipboard(view, slice);
@@ -84,10 +96,12 @@ function DragHandle(options: DragHandleOptions) {
 
     if (!(node instanceof Element)) return;
 
-    const nodePos = nodePosAtDOM(node, view);
+    const nodePos = nodePosAtDOM(node, view, options);
     if (!nodePos) return;
 
-    view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, nodePos)));
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, nodePos))
+    );
   }
 
   let dragHandleElement: HTMLElement | null = null;


### PR DESCRIPTION
## issues

closes #275

## Context

- Fix behavior of image not move when moving the dot handle
- remove **border-radius: 0.2rem;** from class **.ProseMirror-selectednode** because it overrides the default border radius of image after first move.

The solution is similar of made some lines below on another behavior
https://github.com/steven-tey/novel/blob/74dc2c8c28a94fcbb383c768b0e6c13b8dcdc947/packages/headless/src/extensions/drag-and-drop.tsx#L81

Tiptap use the same approach
https://github.com/ueberdosis/tiptap/blob/6ab708b1a2138adafe07535363fdc53ac7a8f208/demos/src/Experiments/GlobalDragHandle/Vue/DragHandle.js#L121-L125

## Evidences

https://github.com/steven-tey/novel/assets/13812512/fd26be66-e128-4e69-915d-6c078f27d182




