### PR TITLE
fix: use per-editor instance of tunnel to render slash command popover

### DIFF
--- a/packages/headless/src/components/editor-command.tsx
+++ b/packages/headless/src/components/editor-command.tsx
@@ -1,14 +1,22 @@
 import { atom, useAtom, useSetAtom } from "jotai";
-import { useEffect, useRef, type ComponentPropsWithoutRef, forwardRef } from "react";
+import {
+  useEffect,
+  useRef,
+  type ComponentPropsWithoutRef,
+  forwardRef,
+  createContext,
+} from "react";
 import tunnel from "tunnel-rat";
 import { novelStore } from "./editor";
 import { Command } from "cmdk";
 import type { Range } from "@tiptap/core";
 
-const t = tunnel();
-
 export const queryAtom = atom("");
 export const rangeAtom = atom<Range | null>(null);
+
+export const EditorCommandTunnelContext = createContext(
+  {} as ReturnType<typeof tunnel>
+);
 
 export const EditorCommandOut = ({
   query,
@@ -37,7 +45,11 @@ export const EditorCommandOut = ({
 
         if (commandRef)
           commandRef.dispatchEvent(
-            new KeyboardEvent("keydown", { key: e.key, cancelable: true, bubbles: true })
+            new KeyboardEvent("keydown", {
+              key: e.key,
+              cancelable: true,
+              bubbles: true,
+            })
           );
 
         return false;
@@ -49,28 +61,42 @@ export const EditorCommandOut = ({
     };
   }, []);
 
-  return <t.Out />;
+  return (
+    <EditorCommandTunnelContext.Consumer>
+      {(tunnelInstance) => <tunnelInstance.Out />}
+    </EditorCommandTunnelContext.Consumer>
+  );
 };
 
-export const EditorCommand = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<typeof Command>>(
-  ({ children, className, ...rest }, ref) => {
-    const commandListRef = useRef<HTMLDivElement>(null);
-    const [query, setQuery] = useAtom(queryAtom);
+export const EditorCommand = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof Command>
+>(({ children, className, ...rest }, ref) => {
+  const commandListRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useAtom(queryAtom);
 
-    return (
-      <t.In>
-        <Command
-          ref={ref}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-          }}
-          id='slash-command'
-          className={className}
-          {...rest}>
-          <Command.Input value={query} onValueChange={setQuery} style={{ display: "none" }} />
-          <Command.List ref={commandListRef}>{children}</Command.List>
-        </Command>
-      </t.In>
-    );
-  }
-);
+  return (
+    <EditorCommandTunnelContext.Consumer>
+      {(tunnelInstance) => (
+        <tunnelInstance.In>
+          <Command
+            ref={ref}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+            }}
+            id="slash-command"
+            className={className}
+            {...rest}
+          >
+            <Command.Input
+              value={query}
+              onValueChange={setQuery}
+              style={{ display: "none" }}
+            />
+            <Command.List ref={commandListRef}>{children}</Command.List>
+          </Command>
+        </tunnelInstance.In>
+      )}
+    </EditorCommandTunnelContext.Consumer>
+  );
+});


### PR DESCRIPTION
## This PR adds per-editor instances of tunnel to render slash command popover

Previously a global tunnel instance was used to render command popover. When using multiple instances of the Editor on the same page, this caused the "/" command to render all the popovers at once.

The proposed solution creates a new tunnel instance for each Editor instance, and passes it down to command components via context. The jotai store is also shared across instances, but it seems that it doesn't matter for now, as it stores the query and range which get reset every time a slash command menu is opened.


https://github.com/steven-tey/novel/assets/9134970/68013cdc-25e3-464e-aa6a-25c86427b702

Closes #304 

