### PR TITLE
fix: rename updated image type

### DIFF
--- a/packages/headless/src/extensions/updated-image.ts
+++ b/packages/headless/src/extensions/updated-image.ts
@@ -1,7 +1,7 @@
 import Image from "@tiptap/extension-image";
 
 const UpdatedImage = Image.extend({
-  name: "updated-image",
+  name: "image",
   addAttributes() {
     return {
       ...this.parent?.(),


### PR DESCRIPTION
**Link to the bug:** [Issue 309](https://github.com/steven-tey/novel/issues/309)

After an image was changed by react-moveable, the type was overridden by "updated-image" which caused the ImageResizer to unrecognize the ContentType, which should be "image." 

Before resize: 

<img width="425" alt="Screenshot 2024-02-27 at 11 19 45 AM" src="https://github.com/steven-tey/novel/assets/49728880/64bdf085-8453-4eba-948b-31202f90b063">

https://github.com/steven-tey/novel/assets/49728880/4ed7c476-7c0c-46b6-ad6d-d2eaee61e3ac

After resize: 

<img width="422" alt="Screenshot 2024-02-27 at 11 20 07 AM" src="https://github.com/steven-tey/novel/assets/49728880/02f2c7cd-dc01-40f0-9d63-0f6a0afe156c">

ImageResizer only handles the type "image"

<img width="692" alt="Screenshot 2024-02-27 at 12 40 02 PM" src="https://github.com/steven-tey/novel/assets/49728880/a7e82987-156d-4bca-8c34-d558142c8e87">


If there is a particular reason to have "updated-image" type feel free to discard this otherwise, this is a tiny fix 😏 


