### PR TITLE
feat: clear nodes on node selector

### DIFF
--- a/apps/web/components/tailwind/selectors/node-selector.tsx
+++ b/apps/web/components/tailwind/selectors/node-selector.tsx
@@ -31,8 +31,7 @@ const items: SelectorItem[] = [
   {
     name: "Text",
     icon: TextIcon,
-    command: (editor) =>
-      editor.chain().focus().toggleNode("paragraph", "paragraph").run(),
+    command: (editor) => editor.chain().focus().clearNodes().run(),
     // I feel like there has to be a more efficient way to do this – feel free to PR if you know how!
     isActive: (editor) =>
       editor.isActive("paragraph") &&
@@ -43,57 +42,56 @@ const items: SelectorItem[] = [
     name: "Heading 1",
     icon: Heading1,
     command: (editor) =>
-      editor.chain().focus().toggleHeading({ level: 1 }).run(),
+      editor.chain().focus().clearNodes().toggleHeading({ level: 1 }).run(),
     isActive: (editor) => editor.isActive("heading", { level: 1 }),
   },
   {
     name: "Heading 2",
     icon: Heading2,
     command: (editor) =>
-      editor.chain().focus().toggleHeading({ level: 2 }).run(),
+      editor.chain().focus().clearNodes().toggleHeading({ level: 2 }).run(),
     isActive: (editor) => editor.isActive("heading", { level: 2 }),
   },
   {
     name: "Heading 3",
     icon: Heading3,
     command: (editor) =>
-      editor.chain().focus().toggleHeading({ level: 3 }).run(),
+      editor.chain().focus().clearNodes().toggleHeading({ level: 3 }).run(),
     isActive: (editor) => editor.isActive("heading", { level: 3 }),
   },
   {
     name: "To-do List",
     icon: CheckSquare,
-    command: (editor) => editor.chain().focus().toggleTaskList().run(),
+    command: (editor) =>
+      editor.chain().focus().clearNodes().toggleTaskList().run(),
     isActive: (editor) => editor.isActive("taskItem"),
   },
   {
     name: "Bullet List",
     icon: ListOrdered,
-    command: (editor) => editor.chain().focus().toggleBulletList().run(),
+    command: (editor) =>
+      editor.chain().focus().clearNodes().toggleBulletList().run(),
     isActive: (editor) => editor.isActive("bulletList"),
   },
   {
     name: "Numbered List",
     icon: ListOrdered,
-    command: (editor) => editor.chain().focus().toggleOrderedList().run(),
+    command: (editor) =>
+      editor.chain().focus().clearNodes().toggleOrderedList().run(),
     isActive: (editor) => editor.isActive("orderedList"),
   },
   {
     name: "Quote",
     icon: TextQuote,
     command: (editor) =>
-      editor
-        .chain()
-        .focus()
-        .toggleNode("paragraph", "paragraph")
-        .toggleBlockquote()
-        .run(),
+      editor.chain().focus().clearNodes().toggleBlockquote().run(),
     isActive: (editor) => editor.isActive("blockquote"),
   },
   {
     name: "Code",
     icon: Code,
-    command: (editor) => editor.chain().focus().toggleCodeBlock().run(),
+    command: (editor) =>
+      editor.chain().focus().clearNodes().toggleCodeBlock().run(),
     isActive: (editor) => editor.isActive("codeBlock"),
   },
 ];


### PR DESCRIPTION
## description

In some cases when select a new node on node selector, it remains with previous selection

https://github.com/steven-tey/novel/assets/13812512/0a297629-c2b1-4fec-ae55-cb51ea59bd93

## What I did

I added `.clearNodes() `to all command chains on select nodes, this way all nodes become a paragraph, before to be applied new node, removing completely old node references.

<img width="800" alt="Screenshot 2024-03-02 at 22 58 15" src="https://github.com/steven-tey/novel/assets/13812512/f116b092-33fb-4a90-83ef-8ef5a493e9b5">

## Result

https://github.com/steven-tey/novel/assets/13812512/b82fd967-8057-47e9-94b2-3cc5c1dcb393

