### PR TITLE
fix: dont trigger slash-command on codeBlock nodes

### DIFF
--- a/packages/headless/src/extensions/slash-command.tsx
+++ b/packages/headless/src/extensions/slash-command.tsx
@@ -12,7 +12,15 @@ const Command = Extension.create({
     return {
       suggestion: {
         char: "/",
-        command: ({ editor, range, props }: { editor: Editor; range: Range; props: any }) => {
+        command: ({
+          editor,
+          range,
+          props,
+        }: {
+          editor: Editor;
+          range: Range;
+          props: any;
+        }) => {
           props.command({ editor, range });
         },
       },
@@ -38,6 +46,15 @@ const renderItems = () => {
         props,
         editor: props.editor,
       });
+
+      const { selection } = props.editor.state;
+
+      const parentNode = selection.$from.node(selection.$from.depth);
+      const blockType = parentNode.type.name;
+
+      if (blockType === "codeBlock") {
+        return false;
+      }
 
       // @ts-ignore
       popup = tippy("body", {


### PR DESCRIPTION
closes #324 

## Description

dont render slash command on nodes of type codeBlock

## Video of it working

https://github.com/steven-tey/novel/assets/13812512/592fbc5b-14d7-4ae0-b400-7995bf9b981b

