### PR TITLE
fix(docs): tailwind extensions guide

### DIFF
--- a/apps/docs/guides/tailwind/extensions.mdx
+++ b/apps/docs/guides/tailwind/extensions.mdx
@@ -20,11 +20,10 @@ import {
 } from "novel/extensions";
 
 import { cx } from "class-variance-authority";
-import { slashCommand } from "./slash-command";
 
-//TODO I am using cx here to get tailwind autocomplete working, idk if someone else can write a regex to just capture the class key in objects
+// TODO I am using cx here to get tailwind autocomplete working, idk if someone else can write a regex to just capture the class key in objects
 
-//You can overwrite the placeholder with your own configuration
+// You can overwrite the placeholder with your own configuration
 const placeholder = Placeholder;
 const tiptapLink = TiptapLink.configure({
   HTMLAttributes: {
@@ -95,8 +94,8 @@ const starterKit = StarterKit.configure({
 export const defaultExtensions = [
   starterKit,
   placeholder,
-  tiptapLink,
-  tiptapImage,
+  TiptapLink,
+  TiptapImage,
   updatedImage,
   taskList,
   taskItem,


### PR DESCRIPTION
Fixed the docs at https://novel.sh/docs/guides/tailwind/extensions as the code is broken.

1. Fixed exports (`tiptapImage` -> `TiptapImage`)
2. Removed unused `slashCommand` import