### PR TITLE
feat: keep slash-command fixed in screen when scrolling window

### DIFF
--- a/packages/headless/src/extensions/slash-command.tsx
+++ b/packages/headless/src/extensions/slash-command.tsx
@@ -1,7 +1,7 @@
 import { Extension } from "@tiptap/core";
 import Suggestion from "@tiptap/suggestion";
 import { ReactRenderer } from "@tiptap/react";
-import tippy from "tippy.js";
+import tippy, { sticky } from "tippy.js";
 import { EditorCommandOut } from "../components/editor-command";
 import type { ReactNode } from "react";
 import type { Editor, Range } from "@tiptap/core";
@@ -65,6 +65,29 @@ const renderItems = () => {
         interactive: true,
         trigger: "manual",
         placement: "bottom-start",
+        sticky: "reference",
+        plugins: [sticky],
+        popperOptions: {
+          strategy: "fixed",
+          modifiers: [
+            {
+              name: "flip",
+              options: {
+                fallbackPlacements: ["top-start"],
+              },
+            },
+            {
+              name: "preventOverflow",
+              options: {
+                altAxis: true,
+                tether: false,
+                padding: {
+                  top: 12,
+                },
+              },
+            },
+          ],
+        },
       });
     },
     onUpdate: (props: { editor: Editor; clientRect: DOMRect }) => {


### PR DESCRIPTION
**Context**

In the moment when the window is scrolling, the slash command disappears and users cannot take any action. The demo below shows the problem. I believe that keeping the slash command fixed in the window is better for accessibility and improves UX.

**Changes**:
- add the [stick](https://atomiks.github.io/tippyjs/v6/all-props/#sticky) plugin when creating the slash command instance with the [tippy.js](https://atomiks.github.io/tippyjs/) lib

---


Demo illustrating the issue (it's is not exactly a issue, btw):

https://github.com/steven-tey/novel/assets/97238331/89d65f60-1df5-44e6-ae36-ccff2782d537


Demo with solution:

https://github.com/steven-tey/novel/assets/97238331/6d552b5d-3d04-4ba5-a610-34e8127fd3f7


