### PR TITLE
Feat: Specify Element to which Slash Commands are Added

### DIFF
--- a/packages/headless/src/extensions/slash-command.tsx
+++ b/packages/headless/src/extensions/slash-command.tsx
@@ -29,7 +29,7 @@ const Command = Extension.create({
   },
 });
 
-const renderItems = (elementRef: RefObject<Element> | null = null) => {
+const renderItems = (elementRef?: RefObject<Element>) => {
   let component: ReactRenderer | null = null;
   let popup: Instance<Props>[] | null = null;
 

--- a/packages/headless/src/extensions/slash-command.tsx
+++ b/packages/headless/src/extensions/slash-command.tsx
@@ -29,7 +29,7 @@ const Command = Extension.create({
   },
 });
 
-const renderItems = (elementRef?: RefObject<Element>) => {
+const renderItems = (elementRef?: RefObject<Element> | null = null) => {
   let component: ReactRenderer | null = null;
   let popup: Instance<Props>[] | null = null;
 

--- a/packages/headless/src/extensions/slash-command.tsx
+++ b/packages/headless/src/extensions/slash-command.tsx
@@ -1,3 +1,4 @@
+import { RefObject } from 'react';
 import { Extension } from "@tiptap/core";
 import type { Editor, Range } from "@tiptap/core";
 import { ReactRenderer } from "@tiptap/react";
@@ -28,7 +29,7 @@ const Command = Extension.create({
   },
 });
 
-const renderItems = () => {
+const renderItems = (elementRef: RefObject<Element> | null = null) => {
   let component: ReactRenderer | null = null;
   let popup: Instance<Props>[] | null = null;
 
@@ -51,7 +52,7 @@ const renderItems = () => {
       // @ts-ignore
       popup = tippy("body", {
         getReferenceClientRect: props.clientRect,
-        appendTo: () => document.body,
+        appendTo: () => elementRef ? elementRef.current : document.body,
         content: component.element,
         showOnCreate: true,
         interactive: true,


### PR DESCRIPTION
The renderItems function can accept an optional parameter, a react ref to an element in DOM, to which slash commands are appended.