### PR TITLE
fix: The tailwind example link on setup page redirects to correct file

### DIFF
--- a/apps/docs/guides/tailwind/setup.mdx
+++ b/apps/docs/guides/tailwind/setup.mdx
@@ -18,7 +18,7 @@ description: "Follow this guide to set up Novel with Tailwindcss"
 </Card>
 
 This example will use the same stucture from here: [Anatomy](/quickstart#anatomy)\
-You can find the full example here: [Tailwind Example](https://github.com/steven-tey/novel/blob/main/apps/web/components/tailwind/editor.tsx)
+You can find the full example here: [Tailwind Example](https://github.com/steven-tey/novel/blob/main/apps/web/components/tailwind/advanced-editor.tsx)
 
 ## Configure Wrapper
 


### PR DESCRIPTION
Fixes Issue: #426 

The tailwind example link on the [setup page](https://novel.sh/docs/guides/tailwind/setup) redirected to a non-existent [editor.tsx](https://github.com/steven-tey/novel/blob/main/apps/web/components/tailwind/editor.tsx) file.

![image](https://github.com/user-attachments/assets/9bec400e-e7ca-427b-8f33-a606f231296c)


Now it redirects to the correct [advanced-editor.tsx](https://github.com/steven-tey/novel/blob/main/apps/web/components/tailwind/advanced-editor.tsx) file 

![image](https://github.com/user-attachments/assets/c9da3508-7d75-4fa1-8b2f-c7c67903ac98)




