### PR TITLE
fix: remove katex styling import inside mathematics extension

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import "@/styles/globals.css";
 import "@/styles/prosemirror.css";
+import 'katex/dist/katex.min.css';
 
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";

--- a/packages/headless/src/extensions/mathematics.ts
+++ b/packages/headless/src/extensions/mathematics.ts
@@ -1,5 +1,3 @@
-import 'katex/dist/katex.min.css';
-
 import { Node, mergeAttributes } from "@tiptap/core";
 import { EditorState } from "@tiptap/pm/state";
 import katex, { type KatexOptions } from "katex";
@@ -41,6 +39,8 @@ declare module "@tiptap/core" {
 
 /**
  * This extension adds support for mathematical symbols with LaTex expression.
+ * 
+ * NOTE: Don't forget to import `katex/dist/katex.min.css` CSS for KaTex styling.
  * 
  * @see https://katex.org/
  */


### PR DESCRIPTION
This pull request addresses issue #432 by removing KaTex styling import inside mathematics extension. Instead, KaTex css must be explicitly imported inside root layout if mathematics extension is used.

Example:
```javascript
import "@/styles/globals.css";
import "@/styles/prosemirror.css";

// KaTex styling import
import 'katex/dist/katex.min.css';
```