### PR TITLE
Fix vertical separator in tailwind example

### DIFF
--- a/examples/novel-tailwind/src/components/editor/advanced-editor.tsx
+++ b/examples/novel-tailwind/src/components/editor/advanced-editor.tsx
@@ -87,14 +87,12 @@ const Editor = ({ initialValue, onChange }: EditorProp) => {
           }}
           className="flex w-fit max-w-[90vw] overflow-hidden rounded-md border border-muted bg-background shadow-xl"
         >
-          <Separator orientation="vertical" />
           <NodeSelector open={openNode} onOpenChange={setOpenNode} />
-          <Separator orientation="vertical" />
-
+          <Separator orientation="vertical" className="h-auto" />
           <LinkSelector open={openLink} onOpenChange={setOpenLink} />
-          <Separator orientation="vertical" />
+          <Separator orientation="vertical" className="h-auto" />
           <TextButtons />
-          <Separator orientation="vertical" />
+          <Separator orientation="vertical" className="h-auto" />
           <ColorSelector open={openColor} onOpenChange={setOpenColor} />
         </EditorBubble>
       </EditorContent>


### PR DESCRIPTION
## Issue:

In the tailwind example's editor bubble menu, the vertical separator (from shadcn) was not visible due to the parent being flex.

![Before](https://github.com/user-attachments/assets/cb638fe1-c197-4cea-8895-79b531e06005)


## Fix:

I added auto height to the separator components.

![After Fix](https://github.com/user-attachments/assets/279420c3-3135-4a68-9cbe-5bc7e616e805)
