### PR TITLE
fix(docs): tailwind extensions guide

### DIFF
--- a/apps/docs/guides/tailwind/extensions.mdx
+++ b/apps/docs/guides/tailwind/extensions.mdx
@@ -96,7 +96,7 @@ export const defaultExtensions = [
   placeholder,
   TiptapLink,
   TiptapImage,
-  updatedImage,
+  UpdatedImage,
   taskList,
   taskItem,
   horizontalRule,


### PR DESCRIPTION
This PR updates the defaultExtensions array by correcting updateImage to UpdatedImage for consistent naming.