### PR TITLE
feat: Added markdownExtension to allow html and markdown string as initial content

### DIFF
--- a/apps/web/components/tailwind/extensions.ts
+++ b/apps/web/components/tailwind/extensions.ts
@@ -148,6 +148,17 @@ const mathematics = Mathematics.configure({
 
 const characterCount = CharacterCount.configure();
 
+const markdownExtension = MarkdownExtension.configure({
+  html: true,
+  tightLists: true,
+  tightListClass: 'tight',
+  bulletListMarker: '-',
+  linkify: false,
+  breaks: false,
+  transformPastedText: false,
+  transformCopiedText: false,
+});
+
 export const defaultExtensions = [
   starterKit,
   placeholder,
@@ -164,7 +175,7 @@ export const defaultExtensions = [
   mathematics,
   characterCount,
   TiptapUnderline,
-  MarkdownExtension,
+  markdownExtension,
   HighlightExtension,
   TextStyle,
   Color,


### PR DESCRIPTION
This PR will allow editor to set initial content in `HTML` or `markdown` format as a string.