### PR TITLE
fix: update getMeta to use uploadKey as param

### DIFF
--- a/packages/headless/src/plugins/upload-images.tsx
+++ b/packages/headless/src/plugins/upload-images.tsx
@@ -13,8 +13,7 @@ export const UploadImagesPlugin = ({ imageClass }: { imageClass: string }) =>
       apply(tr, set) {
         set = set.map(tr.mapping, tr.doc);
         // See if the transaction adds or removes any placeholders
-        //@ts-expect-error - not yet sure what the type I need here
-        const action = tr.getMeta(this);
+        const action = tr.getMeta(uploadKey);
         if (action?.add) {
           const { id, pos, src } = action.add;
 


### PR DESCRIPTION
Looks like `getMeta` accepts `PluginKey` which fixes the type error.

```typescript
getMeta(key: string | Plugin | PluginKey): any;
```