### PR TITLE
feat: upgrade MiniMax default model to MiniMax-M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can deploy your own version of Novel to Vercel with one click:
 To set up Novel locally, you'll need to clone the repository and set up the following environment variables:
 
 - `OPENAI_API_KEY` – your OpenAI API key (you can get one [here](https://platform.openai.com/account/api-keys)), **or**
-- `MINIMAX_API_KEY` – your MiniMax API key (you can get one [here](https://platform.minimax.io)). When set, MiniMax takes priority over OpenAI. Supported models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed`.
+- `MINIMAX_API_KEY` – your MiniMax API key (you can get one [here](https://platform.minimax.io)). When set, MiniMax takes priority over OpenAI. Supported models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
 - `BLOB_READ_WRITE_TOKEN` – your Vercel Blob read/write token (currently [still in beta](https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart), but feel free to [sign up on this form](https://vercel.fyi/blob-beta) for access)
 
 If you've deployed this to Vercel, you can also use [`vc env pull`](https://vercel.com/docs/cli/env#exporting-development-environment-variables) to pull the environment variables from your Vercel project.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can deploy your own version of Novel to Vercel with one click:
 To set up Novel locally, you'll need to clone the repository and set up the following environment variables:
 
 - `OPENAI_API_KEY` – your OpenAI API key (you can get one [here](https://platform.openai.com/account/api-keys)), **or**
-- `MINIMAX_API_KEY` – your MiniMax API key (you can get one [here](https://platform.minimax.io)). When set, MiniMax takes priority over OpenAI. Supported models: `MiniMax-M2.7` (default), `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+- `MINIMAX_API_KEY` – your MiniMax API key (you can get one [here](https://platform.minimax.io)). When set, MiniMax takes priority over OpenAI. Supported models: `MiniMax-M3` (default), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`.
 - `BLOB_READ_WRITE_TOKEN` – your Vercel Blob read/write token (currently [still in beta](https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart), but feel free to [sign up on this form](https://vercel.fyi/blob-beta) for access)
 
 If you've deployed this to Vercel, you can also use [`vc env pull`](https://vercel.com/docs/cli/env#exporting-development-environment-variables) to pull the environment variables from your Vercel project.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ You can deploy your own version of Novel to Vercel with one click:
 
 To set up Novel locally, you'll need to clone the repository and set up the following environment variables:
 
-- `OPENAI_API_KEY` – your OpenAI API key (you can get one [here](https://platform.openai.com/account/api-keys))
+- `OPENAI_API_KEY` – your OpenAI API key (you can get one [here](https://platform.openai.com/account/api-keys)), **or**
+- `MINIMAX_API_KEY` – your MiniMax API key (you can get one [here](https://platform.minimax.io)). When set, MiniMax takes priority over OpenAI. Supported models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed`.
 - `BLOB_READ_WRITE_TOKEN` – your Vercel Blob read/write token (currently [still in beta](https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart), but feel free to [sign up on this form](https://vercel.fyi/blob-beta) for access)
 
 If you've deployed this to Vercel, you can also use [`vc env pull`](https://vercel.com/docs/cli/env#exporting-development-environment-variables) to pull the environment variables from your Vercel project.
@@ -78,7 +79,7 @@ Novel is built on the following stack:
 
 - [Next.js](https://nextjs.org/) – framework
 - [Tiptap](https://tiptap.dev/) – text editor
-- [OpenAI](https://openai.com/) - AI completions
+- [OpenAI](https://openai.com/) / [MiniMax](https://www.minimax.io/) - AI completions
 - [Vercel AI SDK](https://sdk.vercel.ai/docs) – AI library
 - [Vercel](https://vercel.com) – deployments
 - [TailwindCSS](https://tailwindcss.com/) – styles

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,9 +14,9 @@ OPENAI_API_KEY=
 # Get your MiniMax API key here: https://platform.minimax.io
 # When MINIMAX_API_KEY is set it takes priority over OpenAI.
 # MINIMAX_API_KEY=
-# OPTIONAL: Override the default model (default: MiniMax-M2.5)
-# Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed
-# MINIMAX_MODEL=MiniMax-M2.5
+# OPTIONAL: Override the default model (default: MiniMax-M2.7)
+# Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+# MINIMAX_MODEL=MiniMax-M2.7
 
 # OPTIONAL: Vercel Blob (for uploading images)
 # Get your Vercel Blob credentials here: https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,9 +14,9 @@ OPENAI_API_KEY=
 # Get your MiniMax API key here: https://platform.minimax.io
 # When MINIMAX_API_KEY is set it takes priority over OpenAI.
 # MINIMAX_API_KEY=
-# OPTIONAL: Override the default model (default: MiniMax-M2.7)
-# Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
-# MINIMAX_MODEL=MiniMax-M2.7
+# OPTIONAL: Override the default model (default: MiniMax-M3)
+# Supported models: MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed
+# MINIMAX_MODEL=MiniMax-M3
 
 # OPTIONAL: Vercel Blob (for uploading images)
 # Get your Vercel Blob credentials here: https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,10 +2,21 @@
 # secrets in it. If you are cloning this repo, create a copy of this file named
 # ".env" and populate it with your secrets.
 
+# --- LLM Provider (pick ONE) ---
+
+# Option 1: OpenAI (default)
 # Get your OpenAI API key here: https://platform.openai.com/account/api-keys
 OPENAI_API_KEY=
-# OPTIONAL: OpenAI Base URL (default to https://api.openai.com/v1)
-OPENAI_BASE_URL=
+# OPTIONAL: Override the default model (default: gpt-4o-mini)
+# OPENAI_MODEL=gpt-4o-mini
+
+# Option 2: MiniMax (OpenAI-compatible)
+# Get your MiniMax API key here: https://platform.minimax.io
+# When MINIMAX_API_KEY is set it takes priority over OpenAI.
+# MINIMAX_API_KEY=
+# OPTIONAL: Override the default model (default: MiniMax-M2.5)
+# Supported models: MiniMax-M2.5, MiniMax-M2.5-highspeed
+# MINIMAX_MODEL=MiniMax-M2.5
 
 # OPTIONAL: Vercel Blob (for uploading images)
 # Get your Vercel Blob credentials here: https://vercel.com/docs/storage/vercel-blob/quickstart#quickstart

--- a/apps/web/__tests__/ai-provider.integration.test.ts
+++ b/apps/web/__tests__/ai-provider.integration.test.ts
@@ -18,6 +18,24 @@ describe("MiniMax integration", () => {
     }
   });
 
+  it.skipIf(!apiKey)("generates text with MiniMax-M3", async () => {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await generateText({
+      model: minimax("MiniMax-M3"),
+      prompt: "Say hello in exactly 5 words.",
+      maxTokens: 64,
+      temperature: 0.7,
+    });
+
+    expect(result.text).toBeTruthy();
+    expect(result.text.length).toBeGreaterThan(0);
+    console.log("MiniMax-M3 response:", result.text);
+  }, 30000);
+
   it.skipIf(!apiKey)("generates text with MiniMax-M2.7", async () => {
     const minimax = createOpenAI({
       baseURL: "https://api.minimax.io/v1",
@@ -26,14 +44,16 @@ describe("MiniMax integration", () => {
 
     const result = await generateText({
       model: minimax("MiniMax-M2.7"),
-      prompt: "Say hello in exactly 5 words.",
-      maxTokens: 64,
+      prompt: "What is 2+2? Reply with just the number.",
+      maxTokens: 128,
       temperature: 0.7,
     });
 
     expect(result.text).toBeTruthy();
-    expect(result.text.length).toBeGreaterThan(0);
-    console.log("MiniMax-M2.7 response:", result.text);
+    // Strip potential thinking tokens before checking
+    const answer = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+    expect(answer).toContain("4");
+    console.log("MiniMax-M2.7 response:", answer);
   }, 30000);
 
   it.skipIf(!apiKey)("generates text with MiniMax-M2.7-highspeed", async () => {
@@ -44,26 +64,6 @@ describe("MiniMax integration", () => {
 
     const result = await generateText({
       model: minimax("MiniMax-M2.7-highspeed"),
-      prompt: "What is 2+2? Reply with just the number.",
-      maxTokens: 128,
-      temperature: 0.7,
-    });
-
-    expect(result.text).toBeTruthy();
-    // Strip potential thinking tokens before checking
-    const answer = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
-    expect(answer).toContain("4");
-    console.log("MiniMax-M2.7-highspeed response:", answer);
-  }, 30000);
-
-  it.skipIf(!apiKey)("generates text with MiniMax-M2.5 (legacy)", async () => {
-    const minimax = createOpenAI({
-      baseURL: "https://api.minimax.io/v1",
-      apiKey: apiKey!,
-    });
-
-    const result = await generateText({
-      model: minimax("MiniMax-M2.5"),
       prompt: "Say hello in exactly 5 words.",
       maxTokens: 64,
       temperature: 0.7,
@@ -71,10 +71,10 @@ describe("MiniMax integration", () => {
 
     expect(result.text).toBeTruthy();
     expect(result.text.length).toBeGreaterThan(0);
-    console.log("MiniMax-M2.5 response:", result.text);
+    console.log("MiniMax-M2.7-highspeed response:", result.text);
   }, 30000);
 
-  it.skipIf(!apiKey)("streams text with MiniMax-M2.7", async () => {
+  it.skipIf(!apiKey)("streams text with MiniMax-M3", async () => {
     const { streamText } = await import("ai");
     const minimax = createOpenAI({
       baseURL: "https://api.minimax.io/v1",
@@ -82,7 +82,7 @@ describe("MiniMax integration", () => {
     });
 
     const result = await streamText({
-      model: minimax("MiniMax-M2.7"),
+      model: minimax("MiniMax-M3"),
       prompt: "Count from 1 to 5, one number per line.",
       maxTokens: 64,
       temperature: 0.7,

--- a/apps/web/__tests__/ai-provider.integration.test.ts
+++ b/apps/web/__tests__/ai-provider.integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText } from "ai";
+
+/**
+ * Integration tests that call the MiniMax API.
+ * Requires MINIMAX_API_KEY to be set in the environment.
+ *
+ * Run with:
+ *   MINIMAX_API_KEY=<key> pnpm vitest run __tests__/ai-provider.integration.test.ts
+ */
+describe("MiniMax integration", () => {
+  const apiKey = process.env.MINIMAX_API_KEY;
+
+  beforeAll(() => {
+    if (!apiKey) {
+      console.warn("Skipping integration tests: MINIMAX_API_KEY not set");
+    }
+  });
+
+  it.skipIf(!apiKey)("generates text with MiniMax-M2.5", async () => {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await generateText({
+      model: minimax("MiniMax-M2.5"),
+      prompt: "Say hello in exactly 5 words.",
+      maxTokens: 64,
+      temperature: 0.7,
+    });
+
+    expect(result.text).toBeTruthy();
+    expect(result.text.length).toBeGreaterThan(0);
+    console.log("MiniMax-M2.5 response:", result.text);
+  }, 30000);
+
+  it.skipIf(!apiKey)("generates text with MiniMax-M2.5-highspeed", async () => {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await generateText({
+      model: minimax("MiniMax-M2.5-highspeed"),
+      prompt: "What is 2+2? Reply with just the number.",
+      maxTokens: 128,
+      temperature: 0.7,
+    });
+
+    expect(result.text).toBeTruthy();
+    // Strip potential thinking tokens before checking
+    const answer = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+    expect(answer).toContain("4");
+    console.log("MiniMax-M2.5-highspeed response:", answer);
+  }, 30000);
+
+  it.skipIf(!apiKey)("streams text with MiniMax-M2.5", async () => {
+    const { streamText } = await import("ai");
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await streamText({
+      model: minimax("MiniMax-M2.5"),
+      prompt: "Count from 1 to 5, one number per line.",
+      maxTokens: 64,
+      temperature: 0.7,
+    });
+
+    let fullText = "";
+    for await (const chunk of result.textStream) {
+      fullText += chunk;
+    }
+
+    expect(fullText).toBeTruthy();
+    // Strip thinking tokens if present
+    const answer = fullText.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+    expect(answer).toBeTruthy();
+    expect(answer).toContain("1");
+    console.log("MiniMax streaming response:", answer);
+  }, 60000);
+});

--- a/apps/web/__tests__/ai-provider.integration.test.ts
+++ b/apps/web/__tests__/ai-provider.integration.test.ts
@@ -18,7 +18,45 @@ describe("MiniMax integration", () => {
     }
   });
 
-  it.skipIf(!apiKey)("generates text with MiniMax-M2.5", async () => {
+  it.skipIf(!apiKey)("generates text with MiniMax-M2.7", async () => {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await generateText({
+      model: minimax("MiniMax-M2.7"),
+      prompt: "Say hello in exactly 5 words.",
+      maxTokens: 64,
+      temperature: 0.7,
+    });
+
+    expect(result.text).toBeTruthy();
+    expect(result.text.length).toBeGreaterThan(0);
+    console.log("MiniMax-M2.7 response:", result.text);
+  }, 30000);
+
+  it.skipIf(!apiKey)("generates text with MiniMax-M2.7-highspeed", async () => {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: apiKey!,
+    });
+
+    const result = await generateText({
+      model: minimax("MiniMax-M2.7-highspeed"),
+      prompt: "What is 2+2? Reply with just the number.",
+      maxTokens: 128,
+      temperature: 0.7,
+    });
+
+    expect(result.text).toBeTruthy();
+    // Strip potential thinking tokens before checking
+    const answer = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
+    expect(answer).toContain("4");
+    console.log("MiniMax-M2.7-highspeed response:", answer);
+  }, 30000);
+
+  it.skipIf(!apiKey)("generates text with MiniMax-M2.5 (legacy)", async () => {
     const minimax = createOpenAI({
       baseURL: "https://api.minimax.io/v1",
       apiKey: apiKey!,
@@ -36,27 +74,7 @@ describe("MiniMax integration", () => {
     console.log("MiniMax-M2.5 response:", result.text);
   }, 30000);
 
-  it.skipIf(!apiKey)("generates text with MiniMax-M2.5-highspeed", async () => {
-    const minimax = createOpenAI({
-      baseURL: "https://api.minimax.io/v1",
-      apiKey: apiKey!,
-    });
-
-    const result = await generateText({
-      model: minimax("MiniMax-M2.5-highspeed"),
-      prompt: "What is 2+2? Reply with just the number.",
-      maxTokens: 128,
-      temperature: 0.7,
-    });
-
-    expect(result.text).toBeTruthy();
-    // Strip potential thinking tokens before checking
-    const answer = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "").trim();
-    expect(answer).toContain("4");
-    console.log("MiniMax-M2.5-highspeed response:", answer);
-  }, 30000);
-
-  it.skipIf(!apiKey)("streams text with MiniMax-M2.5", async () => {
+  it.skipIf(!apiKey)("streams text with MiniMax-M2.7", async () => {
     const { streamText } = await import("ai");
     const minimax = createOpenAI({
       baseURL: "https://api.minimax.io/v1",
@@ -64,7 +82,7 @@ describe("MiniMax integration", () => {
     });
 
     const result = await streamText({
-      model: minimax("MiniMax-M2.5"),
+      model: minimax("MiniMax-M2.7"),
       prompt: "Count from 1 to 5, one number per line.",
       maxTokens: 64,
       temperature: 0.7,

--- a/apps/web/__tests__/ai-provider.test.ts
+++ b/apps/web/__tests__/ai-provider.test.ts
@@ -78,7 +78,7 @@ describe("getModel", () => {
   it("returns a MiniMax model when MINIMAX_API_KEY is set", () => {
     process.env.MINIMAX_API_KEY = "sk-test-minimax";
     const model = getModel();
-    expect(model.modelId).toBe("MiniMax-M2.5");
+    expect(model.modelId).toBe("MiniMax-M2.7");
   });
 
   it("allows overriding MiniMax model via MINIMAX_MODEL", () => {
@@ -92,6 +92,6 @@ describe("getModel", () => {
     process.env.OPENAI_API_KEY = "sk-test-openai";
     process.env.MINIMAX_API_KEY = "sk-test-minimax";
     const model = getModel();
-    expect(model.modelId).toBe("MiniMax-M2.5");
+    expect(model.modelId).toBe("MiniMax-M2.7");
   });
 });

--- a/apps/web/__tests__/ai-provider.test.ts
+++ b/apps/web/__tests__/ai-provider.test.ts
@@ -78,20 +78,20 @@ describe("getModel", () => {
   it("returns a MiniMax model when MINIMAX_API_KEY is set", () => {
     process.env.MINIMAX_API_KEY = "sk-test-minimax";
     const model = getModel();
-    expect(model.modelId).toBe("MiniMax-M2.7");
+    expect(model.modelId).toBe("MiniMax-M3");
   });
 
   it("allows overriding MiniMax model via MINIMAX_MODEL", () => {
     process.env.MINIMAX_API_KEY = "sk-test-minimax";
-    process.env.MINIMAX_MODEL = "MiniMax-M2.5-highspeed";
+    process.env.MINIMAX_MODEL = "MiniMax-M2.7-highspeed";
     const model = getModel();
-    expect(model.modelId).toBe("MiniMax-M2.5-highspeed");
+    expect(model.modelId).toBe("MiniMax-M2.7-highspeed");
   });
 
   it("prioritizes MiniMax over OpenAI when both keys are set", () => {
     process.env.OPENAI_API_KEY = "sk-test-openai";
     process.env.MINIMAX_API_KEY = "sk-test-minimax";
     const model = getModel();
-    expect(model.modelId).toBe("MiniMax-M2.7");
+    expect(model.modelId).toBe("MiniMax-M3");
   });
 });

--- a/apps/web/__tests__/ai-provider.test.ts
+++ b/apps/web/__tests__/ai-provider.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getModel, getTemperature, hasApiKey } from "@/lib/ai-provider";
+
+// Save original env
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  // Clear provider env vars before each test
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.MINIMAX_API_KEY;
+  delete process.env.OPENAI_MODEL;
+  delete process.env.MINIMAX_MODEL;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("hasApiKey", () => {
+  it("returns false when no API key is set", () => {
+    expect(hasApiKey()).toBe(false);
+  });
+
+  it("returns true when OPENAI_API_KEY is set", () => {
+    process.env.OPENAI_API_KEY = "sk-test-openai-key";
+    expect(hasApiKey()).toBe(true);
+  });
+
+  it("returns true when MINIMAX_API_KEY is set", () => {
+    process.env.MINIMAX_API_KEY = "sk-test-minimax-key";
+    expect(hasApiKey()).toBe(true);
+  });
+
+  it("returns true when both keys are set", () => {
+    process.env.OPENAI_API_KEY = "sk-test-openai-key";
+    process.env.MINIMAX_API_KEY = "sk-test-minimax-key";
+    expect(hasApiKey()).toBe(true);
+  });
+});
+
+describe("getTemperature", () => {
+  it("returns the base temperature when using OpenAI", () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    expect(getTemperature(0.7)).toBe(0.7);
+    expect(getTemperature(0)).toBe(0);
+    expect(getTemperature(1.5)).toBe(1.5);
+  });
+
+  it("clamps temperature to (0.0, 1.0] for MiniMax", () => {
+    process.env.MINIMAX_API_KEY = "sk-test";
+    // Normal value in range
+    expect(getTemperature(0.7)).toBe(0.7);
+    // Zero should be clamped to 0.01
+    expect(getTemperature(0)).toBe(0.01);
+    // Negative should be clamped to 0.01
+    expect(getTemperature(-0.5)).toBe(0.01);
+    // Values above 1.0 should be clamped to 1.0
+    expect(getTemperature(1.5)).toBe(1.0);
+    // Exactly 1.0 is valid
+    expect(getTemperature(1.0)).toBe(1.0);
+  });
+});
+
+describe("getModel", () => {
+  it("returns an OpenAI model when OPENAI_API_KEY is set", () => {
+    process.env.OPENAI_API_KEY = "sk-test-openai";
+    const model = getModel();
+    expect(model.modelId).toBe("gpt-4o-mini");
+  });
+
+  it("allows overriding OpenAI model via OPENAI_MODEL", () => {
+    process.env.OPENAI_API_KEY = "sk-test-openai";
+    process.env.OPENAI_MODEL = "gpt-4o";
+    const model = getModel();
+    expect(model.modelId).toBe("gpt-4o");
+  });
+
+  it("returns a MiniMax model when MINIMAX_API_KEY is set", () => {
+    process.env.MINIMAX_API_KEY = "sk-test-minimax";
+    const model = getModel();
+    expect(model.modelId).toBe("MiniMax-M2.5");
+  });
+
+  it("allows overriding MiniMax model via MINIMAX_MODEL", () => {
+    process.env.MINIMAX_API_KEY = "sk-test-minimax";
+    process.env.MINIMAX_MODEL = "MiniMax-M2.5-highspeed";
+    const model = getModel();
+    expect(model.modelId).toBe("MiniMax-M2.5-highspeed");
+  });
+
+  it("prioritizes MiniMax over OpenAI when both keys are set", () => {
+    process.env.OPENAI_API_KEY = "sk-test-openai";
+    process.env.MINIMAX_API_KEY = "sk-test-minimax";
+    const model = getModel();
+    expect(model.modelId).toBe("MiniMax-M2.5");
+  });
+});

--- a/apps/web/app/api/generate/route.ts
+++ b/apps/web/app/api/generate/route.ts
@@ -1,18 +1,19 @@
-import { openai } from "@ai-sdk/openai";
 import { Ratelimit } from "@upstash/ratelimit";
 import { kv } from "@vercel/kv";
 import { streamText } from "ai";
 import { match } from "ts-pattern";
+import { getModel, getTemperature, hasApiKey } from "@/lib/ai-provider";
 
 // IMPORTANT! Set the runtime to edge: https://vercel.com/docs/functions/edge-functions/edge-runtime
 export const runtime = "edge";
 
 export async function POST(req: Request): Promise<Response> {
-  // Check if the OPENAI_API_KEY is set, if not return 400
-  if (!process.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY === "") {
-    return new Response("Missing OPENAI_API_KEY - make sure to add it to your .env file.", {
-      status: 400,
-    });
+  // Check if an API key is set (supports OpenAI or MiniMax)
+  if (!hasApiKey()) {
+    return new Response(
+      "Missing API key – set OPENAI_API_KEY or MINIMAX_API_KEY in your .env file.",
+      { status: 400 },
+    );
   }
   if (process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN) {
     const ip = req.headers.get("x-forwarded-for");
@@ -118,11 +119,11 @@ export async function POST(req: Request): Promise<Response> {
   const result = await streamText({
     prompt: messages[messages.length - 1].content,
     maxTokens: 4096,
-    temperature: 0.7,
+    temperature: getTemperature(0.7),
     topP: 1,
     frequencyPenalty: 0,
     presencePenalty: 0,
-    model: openai("gpt-4o-mini"),
+    model: getModel(),
   });
 
   return result.toDataStreamResponse();

--- a/apps/web/lib/ai-provider.ts
+++ b/apps/web/lib/ai-provider.ts
@@ -4,7 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
  * Returns the configured LLM model for AI completions.
  *
  * Provider priority:
- *   1. If MINIMAX_API_KEY is set → MiniMax (MiniMax-M2.7)
+ *   1. If MINIMAX_API_KEY is set → MiniMax (MiniMax-M3)
  *   2. If OPENAI_API_KEY is set  → OpenAI  (gpt-4o-mini)
  *
  * MiniMax uses an OpenAI-compatible API, so we reuse @ai-sdk/openai
@@ -16,7 +16,7 @@ export function getModel() {
       baseURL: "https://api.minimax.io/v1",
       apiKey: process.env.MINIMAX_API_KEY,
     });
-    return minimax(process.env.MINIMAX_MODEL ?? "MiniMax-M2.7");
+    return minimax(process.env.MINIMAX_MODEL ?? "MiniMax-M3");
   }
 
   const openai = createOpenAI({

--- a/apps/web/lib/ai-provider.ts
+++ b/apps/web/lib/ai-provider.ts
@@ -4,7 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
  * Returns the configured LLM model for AI completions.
  *
  * Provider priority:
- *   1. If MINIMAX_API_KEY is set → MiniMax (MiniMax-M2.5)
+ *   1. If MINIMAX_API_KEY is set → MiniMax (MiniMax-M2.7)
  *   2. If OPENAI_API_KEY is set  → OpenAI  (gpt-4o-mini)
  *
  * MiniMax uses an OpenAI-compatible API, so we reuse @ai-sdk/openai
@@ -16,7 +16,7 @@ export function getModel() {
       baseURL: "https://api.minimax.io/v1",
       apiKey: process.env.MINIMAX_API_KEY,
     });
-    return minimax(process.env.MINIMAX_MODEL ?? "MiniMax-M2.5");
+    return minimax(process.env.MINIMAX_MODEL ?? "MiniMax-M2.7");
   }
 
   const openai = createOpenAI({

--- a/apps/web/lib/ai-provider.ts
+++ b/apps/web/lib/ai-provider.ts
@@ -1,0 +1,44 @@
+import { createOpenAI } from "@ai-sdk/openai";
+
+/**
+ * Returns the configured LLM model for AI completions.
+ *
+ * Provider priority:
+ *   1. If MINIMAX_API_KEY is set → MiniMax (MiniMax-M2.5)
+ *   2. If OPENAI_API_KEY is set  → OpenAI  (gpt-4o-mini)
+ *
+ * MiniMax uses an OpenAI-compatible API, so we reuse @ai-sdk/openai
+ * with a custom baseURL and apiKey.
+ */
+export function getModel() {
+  if (process.env.MINIMAX_API_KEY) {
+    const minimax = createOpenAI({
+      baseURL: "https://api.minimax.io/v1",
+      apiKey: process.env.MINIMAX_API_KEY,
+    });
+    return minimax(process.env.MINIMAX_MODEL ?? "MiniMax-M2.5");
+  }
+
+  const openai = createOpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+  return openai(process.env.OPENAI_MODEL ?? "gpt-4o-mini");
+}
+
+/**
+ * Clamp temperature for MiniMax: must be in (0.0, 1.0].
+ * OpenAI accepts 0–2, so no clamping needed for OpenAI.
+ */
+export function getTemperature(base: number): number {
+  if (process.env.MINIMAX_API_KEY) {
+    return Math.max(0.01, Math.min(base, 1.0));
+  }
+  return base;
+}
+
+/**
+ * Returns true when an LLM API key is configured (either provider).
+ */
+export function hasApiKey(): boolean {
+  return !!(process.env.MINIMAX_API_KEY || process.env.OPENAI_API_KEY);
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,6 +53,7 @@
     "@types/react": "^18.2.61",
     "@types/react-dom": "18.2.19",
     "tailwindcss": "^3.4.1",
-    "tsconfig": "workspace:*"
+    "tsconfig": "workspace:*",
+    "vitest": "^4.1.0"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       tsconfig:
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.11.24)(vite@8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0))
 
   packages/headless:
     dependencies:
@@ -597,8 +600,17 @@ packages:
   '@egjs/list-differ@1.0.1':
     resolution: {integrity: sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg==}
 
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -893,6 +905,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -901,6 +916,9 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@next/env@15.1.4':
     resolution: {integrity: sha512-2fZ5YZjedi5AGaeoaC0B20zGntEHRhi2SdWcu61i48BllODcAmmtj8n7YarSPt4DaTsJaBFdxQAVEVzgmx2Zpw==}
@@ -968,6 +986,13 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1287,6 +1312,98 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
+
   '@rollup/rollup-android-arm-eabi@4.30.1':
     resolution: {integrity: sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==}
     cpu: [arm]
@@ -1390,6 +1507,9 @@ packages:
 
   '@scena/matrix@1.1.1':
     resolution: {integrity: sha512-JVKBhN0tm2Srl+Yt+Ywqu0oLgLcdemDQlD1OxmN9jaCTwaFPZ7tY8n6dhVgMEaR9qcR7r+kAlMXnSfNyYdE+Vg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -1603,11 +1723,20 @@ packages:
       '@tiptap/core': ^2.7.0
       '@tiptap/pm': ^2.7.0
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
@@ -1730,6 +1859,36 @@ packages:
   '@vercel/kv@1.0.1':
     resolution: {integrity: sha512-uTKddsqVYS2GRAM/QMNNXCTuw9N742mLoGRXoNDcyECaxEXvIHG0dEY+ZnYISV4Vz534VwJO+64fd9XeSggSKw==}
     engines: {node: '>=14.6'}
+    deprecated: 'Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis'
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -1857,6 +2016,10 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
@@ -1931,6 +2094,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.4.1:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
@@ -2031,6 +2198,9 @@ packages:
     resolution: {integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==}
     engines: {node: '>=16'}
     hasBin: true
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cosmiconfig-typescript-loader@6.1.0:
     resolution: {integrity: sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==}
@@ -2162,6 +2332,9 @@ packages:
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
     engines: {node: '>=18'}
@@ -2192,6 +2365,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -2203,6 +2379,10 @@ packages:
   eventsource-parser@3.0.0:
     resolution: {integrity: sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2229,6 +2409,15 @@ packages:
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2298,6 +2487,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -2310,6 +2500,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -2514,6 +2705,76 @@ packages:
   keycon@1.4.0:
     resolution: {integrity: sha512-p1NAIxiRMH3jYfTeXRs2uWbVJ1WpEjpi8ktzUyBJsX7/wn2qu2VRXktneBLNtKNxJmlUYxRi9gOJt1DuthXR7A==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -2595,6 +2856,9 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
@@ -2734,6 +2998,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2749,6 +3018,7 @@ packages:
   next@15.1.4:
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -2770,6 +3040,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -2798,6 +3069,9 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   openai@4.78.1:
     resolution: {integrity: sha512-drt0lHZBd2lMyORckOXFPQTmnGLWSLt8VK0W9BhOKWpMFBEoHMoz5gxMPmVq5icp+sOrsbMnsmZTVHUlKvD1Ow==}
@@ -2889,6 +3163,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2898,6 +3175,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -2977,6 +3258,10 @@ packages:
 
   postcss@8.5.1:
     resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
@@ -3178,6 +3463,11 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.30.1:
     resolution: {integrity: sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3221,6 +3511,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3245,6 +3538,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -3263,6 +3557,12 @@ packages:
     resolution: {integrity: sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -3368,12 +3668,27 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
@@ -3565,6 +3880,84 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue@3.5.13:
     resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
     peerDependencies:
@@ -3595,6 +3988,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -4084,7 +4482,23 @@ snapshots:
 
   '@egjs/list-differ@1.0.1': {}
 
+  '@emnapi/core@1.9.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4279,6 +4693,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -4299,6 +4715,13 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@next/env@15.1.4': {}
 
@@ -4339,6 +4762,10 @@ snapshots:
       fastq: 1.18.0
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4771,6 +5198,55 @@ snapshots:
 
   '@remirror/core-constants@3.0.0': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
+
   '@rollup/rollup-android-arm-eabi@4.30.1':
     optional: true
 
@@ -4840,6 +5316,8 @@ snapshots:
   '@scena/matrix@1.1.1':
     dependencies:
       '@daybrush/utils': 1.13.0
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/counter@0.1.3': {}
 
@@ -5068,6 +5546,16 @@ snapshots:
       '@tiptap/core': 2.11.2(@tiptap/pm@2.11.2)
       '@tiptap/pm': 2.11.2
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
       '@types/node': 22.10.6
@@ -5075,6 +5563,8 @@ snapshots:
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/diff-match-patch@1.0.36': {}
 
@@ -5185,6 +5675,47 @@ snapshots:
   '@vercel/kv@1.0.1':
     dependencies:
       '@upstash/redis': 1.25.1
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@vue/compiler-core@3.5.13':
     dependencies:
@@ -5328,6 +5859,8 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   async-retry@1.3.3:
     dependencies:
       retry: 0.13.1
@@ -5391,6 +5924,8 @@ snapshots:
   caniuse-lite@1.0.30001692: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@5.4.1: {}
 
@@ -5510,6 +6045,8 @@ snapshots:
       meow: 12.1.1
       split2: 4.2.0
 
+  convert-source-map@2.0.0: {}
+
   cosmiconfig-typescript-loader@6.1.0(@types/node@22.10.6)(cosmiconfig@9.0.0(typescript@5.7.3))(typescript@5.7.3):
     dependencies:
       '@types/node': 22.10.6
@@ -5567,8 +6104,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.0.3:
-    optional: true
+  detect-libc@2.0.3: {}
 
   detect-node-es@1.1.0: {}
 
@@ -5612,6 +6148,8 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.24.2:
     optionalDependencies:
@@ -5657,11 +6195,17 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.6
+
   event-target-shim@5.0.1: {}
 
   eventsource-parser@1.1.2: {}
 
   eventsource-parser@3.0.0: {}
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -5692,6 +6236,10 @@ snapshots:
   fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fill-range@7.1.1:
     dependencies:
@@ -5966,6 +6514,55 @@ snapshots:
       '@scena/event-emitter': 1.0.5
       keycode: 2.2.1
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.3
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -6031,6 +6628,10 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-it-task-lists@2.1.1: {}
 
@@ -6300,6 +6901,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   nanoid@3.3.8: {}
 
   next-themes@0.2.1(next@15.1.4(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
@@ -6349,6 +6952,8 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  obug@2.1.1: {}
 
   openai@4.78.1(zod@3.24.1):
     dependencies:
@@ -6438,11 +7043,15 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -6503,6 +7112,12 @@ snapshots:
   postcss@8.5.1:
     dependencies:
       nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6811,6 +7426,27 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  rolldown@1.0.0-rc.9:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
+
   rollup@4.30.1:
     dependencies:
       '@types/estree': 1.0.6
@@ -6900,6 +7536,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.2:
@@ -6935,6 +7573,10 @@ snapshots:
     dependencies:
       svelte: 5.17.4
       swrev: 4.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -7070,12 +7712,23 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tippy.js@6.3.7:
     dependencies:
@@ -7288,6 +7941,48 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
+  vite@8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.11.24
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      yaml: 2.7.0
+
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.11.24)(vite@8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.0(@types/node@20.11.24)(jiti@2.4.2)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 20.11.24
+    transitivePeerDependencies:
+      - msw
+
   vue@3.5.13(typescript@5.7.3):
     dependencies:
       '@vue/compiler-dom': 3.5.13
@@ -7320,6 +8015,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider default model to MiniMax-M3 (latest flagship) while keeping M2.7 / M2.7-highspeed as alternatives and dropping the legacy M2.5 line.

## Changes
- `apps/web/lib/ai-provider.ts`: switch default from `MiniMax-M2.7` to `MiniMax-M3`; update docstring
- `apps/web/__tests__/ai-provider.test.ts`: assert default model is M3, M2.7-highspeed as override, remove M2.5-highspeed case
- `apps/web/__tests__/ai-provider.integration.test.ts`: cover M3 (text + streaming), keep M2.7 and M2.7-highspeed, remove M2.5 legacy test
- `apps/web/.env.example`: default `MINIMAX_MODEL=MiniMax-M3`; supported models list updated
- `README.md`: supported models list updated

## Why
MiniMax-M3 is the latest flagship model: 512K context window, up to 128K output, and image input support. M2.7 / M2.7-highspeed are retained for users who want the prior generation; the older M2.5 line is dropped.

## Models
- `MiniMax-M3` (default) — latest flagship
- `MiniMax-M2.7` — previous generation
- `MiniMax-M2.7-highspeed` — previous generation, low-latency

Removed: `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.

## Testing
- All 11 unit tests pass (`pnpm vitest run __tests__/ai-provider.test.ts`)
- Integration test file updated to cover M3, M2.7, M2.7-highspeed (live API)
- Base URL unchanged: `https://api.minimax.io/v1` (OpenAI-compatible adapter)
